### PR TITLE
implicit grad on backward only run on scalar value.

### DIFF
--- a/smalltensor/ops.py
+++ b/smalltensor/ops.py
@@ -144,6 +144,8 @@ class Expand(Function):
 
   def backward(self, grad_output):
     axs = broadcast_indices(self.in_shape, grad_output.shape)
+    if len(self.in_shape) < len(grad_output.shape):
+      return np.sum(grad_output, axs)
     return np.sum(grad_output, axs, keepdims=True)
 
 class Permute(Function):

--- a/smalltensor/ops.py
+++ b/smalltensor/ops.py
@@ -70,7 +70,7 @@ class Max(Function):
       ret[np.arange(len(a)), argmax] = 1
     else:
       ret[np.unravel_index(argmax, a.shape)] = 1
-    return ret
+    return grad_output*ret
 
 # *********** Binary ops **********
 
@@ -105,7 +105,7 @@ class Pow(Function):
 
  def backward(self, grad_output):
    a, b, ret = self.saved_tensor
-   return b*ret/a, ret*np.log(a)
+   return grad_output*b*ret/a, grad_output*ret*np.log(a)
 
 class Eq(Function):
   def forward(self, a, b):
@@ -121,18 +121,21 @@ class Matmul(Function):
 
   def backward(self, grad_output):
     a, b = self.saved_tensor
-    return np.matmul(grad_output, np.transpose(b)), \
-           np.matmul(np.transpose(a), grad_output)
+    # https://pytorch.org/docs/stable/generated/torch.matmul.html
+    # N-D, N>2 ndarray are treated as stacks of 2-D matrices
+    # Transposing it means swapping the last 2 dims (-1 and -2)
+    return np.matmul(grad_output, np.swapaxes(b, -1, -2)), \
+           np.matmul(np.swapaxes(a, -1, -2), grad_output)
 
 # *********** Movement ops **********
 
 class Reshape(Function):
   def forward(self, a, shape):
     self.in_shape = a.shape
-    return np.reshape(a, *shape)
+    return np.reshape(a, shape)
 
   def backward(self, grad_output):
-    return np.reshape(grad_output, *self.in_shape)
+    return np.reshape(grad_output, self.in_shape)
 
 class Expand(Function):
   def forward(self, a, shape):

--- a/smalltensor/tensor.py
+++ b/smalltensor/tensor.py
@@ -118,8 +118,10 @@ class Tensor:
 
   # Movement ops
   def reshape(self, *shape): return Tensor._reshape(self, shape=shape)
-  def expand(self, *shape): return Tensor._expand(self, shape=shape)
   def permute(self, *order): return Tensor._permute(self, order=order)
+  # NOTES: Should we mirror PyTorch where passing -1 means keeping that dim size the same?
+  # https://pytorch.org/docs/stable/generated/torch.Tensor.expand.html
+  def expand(self, *shape): return Tensor._expand(self, shape=shape)
 
   # TODO:
   # Processing ops

--- a/smalltensor/tensor.py
+++ b/smalltensor/tensor.py
@@ -59,6 +59,8 @@ class Tensor:
     Compute the gradient of the current Tensor w.r.t graph leaves. The graph is differentiated using the chain rule. """
     if self.requires_grad is False:
       raise RuntimeError("Tensor does not require grad and does not have ctx. Make sure all of the tensors have requires_grad=True")
+    if self.shape != (1,) and self.shape != ():
+      raise RuntimeError(f"grad can be implicitly created only for scalar outputs, while Tensor is of shape {self.shape}")
     self.grad = Tensor.ones(*self.shape)
     for t0 in reversed(self.toposort()):
       assert t0._ctx is not None

--- a/smalltensor/tensor.py
+++ b/smalltensor/tensor.py
@@ -90,7 +90,7 @@ class Tensor:
 
   # Unary ops
   # Should neg be a standalone function or using sub?
-  def __neg__(self): return Tensor._neg(self)
+  def neg(self): return Tensor._neg(self)
   def inv(self): return Tensor._inv(self)
   def relu(self): return Tensor._relu(self)
   def log(self): return Tensor._log(self)
@@ -104,19 +104,9 @@ class Tensor:
   def div(self, x): return self * (x.inv() if isinstance(x, Tensor) else (1/x))
   def eq(self, x): return Tensor._eq(self, x)
   def pow(self, x): return Tensor.broadcasted_tensor(Tensor._pow, self, x)
+  # NOTES: Numpy allow broadcasting on batch dim (not the last 2 dims)
+  # NOTES: However, we have not implement it for backward, should we?
   def matmul(self, x): return Tensor._matmul(self, x)
-
-  # NOTES: This all could be generate using setattr, but im keeping this for clarity.
-  __add__ = add
-  __sub__ = sub
-  __mul__ = mul
-  __truediv__ = div
-  __pow__ = pow
-  __matmul__ = matmul
-  def __radd__(self, x): return Tensor.add(x, self)
-  def __rsub__(self, x): return Tensor.sub(x, self)
-  def __rmul__(self, x): return Tensor.mul(x, self)
-  def __rtruediv__(self, x): return Tensor.div(x, self)
 
   # Reduce ops
   def sum(self, dim=None, keepdims=False): return Tensor._sum(self, dim=dim, keepdims=keepdims)
@@ -134,6 +124,20 @@ class Tensor:
   # TODO:
   # Processing ops
   # conv2d?
+
+  # NOTES: This all could be generate using setattr, but im keeping this for clarity.
+  __neg__ = neg
+  __add__ = add
+  __sub__ = sub
+  __mul__ = mul
+  __truediv__ = div
+  __pow__ = pow
+  __matmul__ = matmul
+  # NOTES: Are there any cool tricks to golf this?
+  def __radd__(self, x): return Tensor.add(x, self)
+  def __rsub__(self, x): return Tensor.sub(x, self)
+  def __rmul__(self, x): return Tensor.mul(x, self)
+  def __rtruediv__(self, x): return Tensor.div(x, self)
 
 
 class Function:

--- a/smalltensor/tensor.py
+++ b/smalltensor/tensor.py
@@ -37,6 +37,8 @@ class Tensor:
   @classmethod
   def ones(cls, *args, **kwargs): return cls(np.ones(*shape, dtype=np.float32), **kwargs)
 
+  def numpy(self) -> np.ndarray: return np.array(self.item)
+
   def __repr__(self):
     return f"Tensor({np.array2string(self.item, prefix=7*' ', precision=4, separator=', ')}" + (f", requires_grad={self.requires_grad})" if self.requires_grad is True else ")")
 
@@ -93,6 +95,7 @@ class Tensor:
   def relu(self): return Tensor._relu(self)
   def log(self): return Tensor._log(self)
   def exp(self): return Tensor._exp(self)
+  def square(self): return self*self
 
   # Binary ops
   def add(self, x): return Tensor.broadcasted_tensor(Tensor._add, self, x)

--- a/smalltensor/utils.py
+++ b/smalltensor/utils.py
@@ -38,9 +38,10 @@ def broadcast_indices(s1: Tuple[int, ...], s2: Tuple[int, ...]):
   broadcast_indices((1, 2), (3, 2)) == (0,)
   broadcast_indices((6, 7), (5, 6, 1)) == (0, 2) """
   ret, mlen = [], max(len(s1), len(s2))
-  for idx, dims in enumerate(zip_longest(*[reversed(s) for s in [s1, s2]], fillvalue=1)):
+  for idx, dims in enumerate(zip_longest(*[reversed(s) for s in [s1, s2]])):
+    dims = tuple(s for s in dims if s is not None)
     if min(dims) != 1 and (min(dims) != max(dims)):
       raise ValueError(f"Cannot broadcast shapes of {s1} with {s2} at idx:{idx} ({dims[0]} and {dims[1]})")
-    elif min(dims) == 1:
+    elif min(dims) == 1 and (min(dims) != max(dims)) or len(dims) == 1:
       ret.append(mlen-idx-1)
   return tuple(reversed(ret))

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,0 +1,20 @@
+from itertools import combinations, chain
+from functools import reduce
+import random
+
+# https://docs.python.org/2/library/itertools.html#recipes
+def powerset(iterable):
+  """
+  powerset([1,2,3]) --> () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3) """
+  s = list(iterable)
+  return chain.from_iterable(combinations(s, r) for r in range(len(s)+1))
+
+def random_reduce(fxn, iter, l):
+  """
+  Like reduce, but only on random number of elements in iter
+  If l==len(iter), it is just a normal reduce
+  Eg: random_reduce(lambda x,y:x+y, [1, 2, 3], 2) = [4, 2]
+  Used for generating reshape reshape for testing"""
+  z = random.sample(range(len(iter)), l) 
+  s = reduce(fxn, [iter[i] for i in z])
+  return [s] + [j for i,j in enumerate(iter) if i not in z]

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2,11 +2,9 @@ import random
 
 import pytest
 from pytest import approx
-
 import torch
 
 from smalltensor.tensor import Tensor
-from smalltensor import set_printoptions
 
 def test_diamond_backward():
   """

--- a/test/test_broadcast.py
+++ b/test/test_broadcast.py
@@ -21,3 +21,4 @@ def test_broadcast_indices_equal():
 def test_broadcast_indices_unequal():
   assert broadcast_indices((7,), (5, 1, 7)) == (0, 1)
   assert broadcast_indices((6, 7), (5, 6, 1)) == (0, 2)
+  assert broadcast_indices((1, 1), (1,)) == (0,)

--- a/test/test_broadcast.py
+++ b/test/test_broadcast.py
@@ -21,13 +21,3 @@ def test_broadcast_indices_equal():
 def test_broadcast_indices_unequal():
   assert broadcast_indices((7,), (5, 1, 7)) == (0, 1)
   assert broadcast_indices((6, 7), (5, 6, 1)) == (0, 2)
-
-import numpy as np
-from smalltensor import Tensor
-def test_broadcast_backward():
-  a = Tensor.randn(1, 3, requires_grad=True)
-  b = Tensor.randn(3, 3, requires_grad=True)
-  c = a + b
-  c.backward()
-  assert a.grad.eq(Tensor.ones(1, 3) * 3)
-  assert b.grad.eq(Tensor.ones(3, 3))

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -4,13 +4,13 @@ import torch
 import numpy as np
 from smalltensor import Tensor
 
-def compare(m, x, y, atol, rtol):
-  assert x.shape == y.shape
-  if not np.allclose(x, y, atol, rtol):
-    raise Exception(f"{m} failed with shape {x.shape} {y.shape}")
+def compare(m, st, tt, atol, rtol):
+  assert st.shape == tt.shape
+  if not np.allclose(st, tt, atol, rtol):
+    raise Exception(f"{m} failed with shape {st.shape} {tt.shape}")
 
 def util_test_ops(shapes: List[Tuple[int]], torch_fxn, smallt_fxn, 
-                  backward=True, a=-1.0, b=1.0,
+                  backward=True, a=-1.0, b=3.0,
                   atol=1e-3, rtol=1e-3):
   """
   shapes: list of shapes of Tensor
@@ -22,7 +22,7 @@ def util_test_ops(shapes: List[Tuple[int]], torch_fxn, smallt_fxn,
 
   https://numpy.org/doc/stable/reference/random/generated/numpy.random.random_sample.html#numpy.random.random_sample
   a, b: lower and upper bound of numpy random sample in Uniform[a, b), a < b """
-  sts = [Tensor(b*(a+np.random.random(size=s).astype(np.float32)), requires_grad=backward) for s in shapes]
+  sts = [Tensor((b-a)*(a+np.random.random(size=s).astype(np.float32)), requires_grad=backward) for s in shapes]
   tts = [torch.tensor(a.numpy(), requires_grad=backward) for a in sts]
 
   # Test forward
@@ -37,20 +37,35 @@ def util_test_ops(shapes: List[Tuple[int]], torch_fxn, smallt_fxn,
     for i, (st, tt) in enumerate(zip(sts, tts)):
       compare(f"backward pass of tensor idx {i}", st.grad.numpy(), tt.grad.detach().numpy(), atol, rtol)
 
+# Unary ops
+def test_neg():
+  util_test_ops([(10,10)], lambda x: -x, Tensor.__neg__)
+def test_inv():
+  util_test_ops([(10,10)], lambda x: 1/x, lambda x: x.inv())
+def test_log():
+  util_test_ops([(10,10)], lambda x: torch.log(x), lambda x: x.log(), a=0)
+def test_relu():
+  util_test_ops([(10,10)], lambda x: torch.relu(x), lambda x: x.relu())
+def test_exp():
+  util_test_ops([(10,10)], lambda x: torch.exp(x), lambda x: x.exp())
+
 # Binary ops
 def test_add():
-  util_test_ops([(10, 10), (10, 10)], lambda x,y: x+y, Tensor.add)
+  util_test_ops([(10,10), (10,10)], lambda x,y: x+y, lambda x,y: x.add(y))
 def test_sub():
-  util_test_ops([(10, 10), (10, 10)], lambda x,y: x-y, Tensor.sub)
+  util_test_ops([(10,10), (10,10)], lambda x,y: x-y, lambda x,y: x.sub(y))
 def test_mul():
-  util_test_ops([(10, 10), (10, 10)], lambda x,y: x*y, Tensor.mul)
+  util_test_ops([(10,10), (10,10)], lambda x,y: x*y, lambda x,y: x.mul(y))
 def test_div():
-  util_test_ops([(10, 10), (10, 10)], lambda x,y: x/y, Tensor.div)
+  util_test_ops([(10,10), (10,10)], lambda x,y: x/y, lambda x,y: x.div(y))
 def test_pow():
-  util_test_ops([(10, 10)], lambda x: x**2, lambda x: Tensor.pow(x,2), a=0)
-  # util_test_ops([(10, 10), (10, 10)], lambda x,y: torch.pow(x,y), Tensor.pow, a=0)
+  util_test_ops([(10,10), (10,10)], lambda x,y: torch.pow(x,y), lambda x,y: x.pow(y), a=0)
 def test_matmul():
-  util_test_ops([(10, 10), (10, 10)], lambda x,y: torch.matmul(x,y), Tensor.matmul)
+  util_test_ops([(20,10), (10,20)], lambda x,y: torch.matmul(x,y), lambda x,y: x.matmul(y))
+  # Incorrect shape
+  with pytest.raises(ValueError):
+    util_test_ops([(20,20), (10,20)], lambda x,y: torch.matmul(x,y), lambda x,y: x.matmul(y))
+  util_test_ops([(10,10,20), (10,20,10)], lambda x,y: torch.matmul(x,y), lambda x,y: x.matmul(y))
 
 np.seterr(divide='raise')   # Numpy treat div 0 as warning and return inf, not exception
 def test_div_raise_zero():
@@ -59,32 +74,30 @@ def test_div_raise_zero():
 def test_inv_raise_zero():
   with pytest.raises((ZeroDivisionError, FloatingPointError)): Tensor(0).inv()
 
-def test_neg():
-  util_test_ops([(10, 10)], lambda x: -x, Tensor.__neg__)
-def test_inv():
-  util_test_ops([(10, 10)], lambda x: 1/x, Tensor.inv)
-def test_log():
-  util_test_ops([(10, 10)], lambda x: torch.log(x), Tensor.log, a=0)
-def test_relu():
-  util_test_ops([(10, 10)], lambda x: torch.relu(x), Tensor.relu)
-def test_exp():
-  util_test_ops([(10, 10)], lambda x: torch.exp(x), Tensor.exp)
+@pytest.mark.skip(reason="not written")
+def test_broadcasted():
+  pass
 
-@pytest.mark.skip(reason="not written")
+# Reduce ops
 def test_sum():
-  pass
-@pytest.mark.skip(reason="not written")
+  util_test_ops([(10,10)], lambda x: torch.sum(x), Tensor.sum)
 def test_max():
-  pass
-@pytest.mark.skip(reason="not written")
+  util_test_ops([(10,10)], lambda x: torch.max(x), Tensor.max)
 def test_min():
-  pass
-@pytest.mark.skip(reason="not written")
+  util_test_ops([(10,10)], lambda x: torch.min(x), Tensor.min)
 def test_mean():
-  pass
-@pytest.mark.skip(reason="not written")
+  util_test_ops([(10,10)], lambda x: torch.mean(x), Tensor.mean)
+
+# Movement ops
 def test_expand():
-  pass
-@pytest.mark.skip(reason="not written")
+  util_test_ops([(1,2,3,4)], lambda x: x.expand(2,2,3,4), lambda x: x.expand(2,2,3,4))
+@pytest.mark.skip(reason="broken")
+def test_expand_new_dim():
+  util_test_ops([(1,2,3,4)], lambda x: x.expand(1,1,2,3,4), lambda x: x.expand(1,1,2,3,4))
 def test_permute():
-  pass
+  util_test_ops([(1,2,3,4)], lambda x: x.permute(1,0,3,2), lambda x: x.permute(1,0,3,2))
+def test_reshape():
+  util_test_ops([(1,2,3,4)], lambda x: x.reshape(2,1,3,4), lambda x: x.reshape(2,1,3,4))
+def test_reshape_combine():
+  util_test_ops([(1,2,3,4)], lambda x: x.reshape(2,3,4), lambda x: x.reshape(2,3,4))
+  util_test_ops([(1,2,3,4)], lambda x: x.reshape(2,12), lambda x: x.reshape(2,12))

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -48,6 +48,8 @@ def test_relu():
   util_test_ops([(10,10)], lambda x: torch.relu(x), lambda x: x.relu())
 def test_exp():
   util_test_ops([(10,10)], lambda x: torch.exp(x), lambda x: x.exp())
+def test_square():
+  util_test_ops([(10,10)], lambda x: torch.square(x), lambda x: x.square())
 
 # Binary ops
 def test_add():
@@ -91,9 +93,9 @@ def test_mean():
 # Movement ops
 def test_expand():
   util_test_ops([(1,2,3,4)], lambda x: x.expand(2,2,3,4), lambda x: x.expand(2,2,3,4))
-@pytest.mark.skip(reason="broken")
 def test_expand_new_dim():
   util_test_ops([(1,2,3,4)], lambda x: x.expand(1,1,2,3,4), lambda x: x.expand(1,1,2,3,4))
+  util_test_ops([(10,2,3,4)], lambda x: x.expand(1,1,10,2,3,4), lambda x: x.expand(1,1,10,2,3,4))
 def test_permute():
   util_test_ops([(1,2,3,4)], lambda x: x.permute(1,0,3,2), lambda x: x.permute(1,0,3,2))
 def test_reshape():

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1,99 +1,90 @@
-import random
-import math
-from inspect import signature
-
+from typing import List, Tuple
 import pytest
-from pytest import approx
+import torch
 import numpy as np
+from smalltensor import Tensor
 
-from smalltensor.tensor import Tensor
+def compare(m, x, y, atol, rtol):
+  assert x.shape == y.shape
+  if not np.allclose(x, y, atol, rtol):
+    raise Exception(f"{m} failed with shape {x.shape} {y.shape}")
 
-def central_difference(f, *vals, arg=0, epsilon=1e-6):
-  # https://en.wikipedia.org/wiki/Finite_difference for more details.
-  def _diff(vals, arg, epsilon):
-    # Change vals[arg] by eps
-    return [i+epsilon if idx == arg else i for idx, i in enumerate(vals)]
+def util_test_ops(shapes: List[Tuple[int]], torch_fxn, smallt_fxn, 
+                  backward=True, a=-1.0, b=1.0,
+                  atol=1e-3, rtol=1e-3):
+  """
+  shapes: list of shapes of Tensor
+  torch_fxn: PyTorch's ops
+  smallt_fxn: smalltensor's ops
+  backward: test for backward pass
+  atol: absolute difference
+  rtol: relative defference
 
-  # delta_h_f(x) = f(x+h/2) - f(x-h/2)
-  # f'(x) = delta_h_f(x)/h
-  return (f(*_diff(vals, arg, epsilon/2)) - f(*_diff(vals, arg, -epsilon/2)))/epsilon
+  https://numpy.org/doc/stable/reference/random/generated/numpy.random.random_sample.html#numpy.random.random_sample
+  a, b: lower and upper bound of numpy random sample in Uniform[a, b), a < b """
+  sts = [Tensor(b*(a+np.random.random(size=s).astype(np.float32)), requires_grad=backward) for s in shapes]
+  tts = [torch.tensor(a.numpy(), requires_grad=backward) for a in sts]
 
-# FIX: Should we test forward and backward seperately?
-def util_test_ops(py_fxn, smt_fxn, atol=1e-5, rtol=1e-5):
-  nparams = len(signature(py_fxn).parameters)
-  pyi = [np.random.rand(3, 3) for n in range(nparams)]
-  sti = [Tensor(d, requires_grad=True) for d in pyi]
-  py_val, st_val  = py_fxn(*pyi), smt_fxn(*sti)
-  # Compare forward result from python ops and smalltensor ops
-  assert st_val.item == approx(py_val, abs=atol, rel=rtol)
+  # Test forward
+  st_val = smallt_fxn(*sts)
+  tt_val = torch_fxn(*tts)
+  compare("forward pass", st_val.numpy(), tt_val.detach().numpy(), atol, rtol)
 
-  if nparams > 1:
-    sti_1 = (2, sti[1])
-    sti_2 = (sti[0], 2)
-    # Mix Tensor with Python number
-    st_val1, py_val1 = smt_fxn(*sti_1), py_fxn(2, pyi[1])
-    st_val2, py_val2 = smt_fxn(*sti_2), py_fxn(pyi[0], 2)
-    # Compare forward result from python ops and smalltensor ops
-    assert st_val1.item == approx(py_val1, abs=atol, rel=rtol), f"const idx 0 of {smt_fxn} fail"
-    assert st_val2.item == approx(py_val2, abs=atol, rel=rtol), f"const idx 1 of {smt_fxn} fail"
-    # Mix Tensor with np.ndarray, but only if using Tensor's method
-    sti_3 = (sti[0], pyi[1])
-    st_val3 = smt_fxn(*sti_3)
-    assert st_val3.item == approx(py_val, abs=atol, rel=rtol), "tensor ops on numpy fail"
+  if backward:
+    # Test backward
+    st_val = st_val.mean().backward()
+    tt_val = tt_val.mean().backward()
+    for i, (st, tt) in enumerate(zip(sts, tts)):
+      compare(f"backward pass of tensor idx {i}", st.grad.numpy(), tt.grad.detach().numpy(), atol, rtol)
 
-  # Compare backward result from python ops and smalltensor ops
-  st_val.backward()
-  for idx in range(nparams):
-    grad = central_difference(py_fxn, *pyi, arg=idx)
-    assert grad == approx(sti[idx].grad.item, abs=atol, rel=rtol), "backward fail"
-
-
+# Binary ops
 def test_add():
-  util_test_ops(lambda x,y: x+y, Tensor.add)
+  util_test_ops([(10, 10), (10, 10)], lambda x,y: x+y, Tensor.add)
 def test_sub():
-  util_test_ops(lambda x,y: x-y, Tensor.sub)
+  util_test_ops([(10, 10), (10, 10)], lambda x,y: x-y, Tensor.sub)
 def test_mul():
-  util_test_ops(lambda x,y: x*y, Tensor.mul)
+  util_test_ops([(10, 10), (10, 10)], lambda x,y: x*y, Tensor.mul)
 def test_div():
-  util_test_ops(lambda x,y: x/y, Tensor.div)
-  util_test_ops(lambda x,y: x/y, Tensor.div)
-def test_rdiv():
-  assert (2/Tensor(1)).item == 2
+  util_test_ops([(10, 10), (10, 10)], lambda x,y: x/y, Tensor.div)
+def test_pow():
+  util_test_ops([(10, 10)], lambda x: x**2, lambda x: Tensor.pow(x,2), a=0)
+  # util_test_ops([(10, 10), (10, 10)], lambda x,y: torch.pow(x,y), Tensor.pow, a=0)
+def test_matmul():
+  util_test_ops([(10, 10), (10, 10)], lambda x,y: torch.matmul(x,y), Tensor.matmul)
 
-# Numpy treat div 0 as warning and return inf, not exception
-np.seterr(divide='raise')
+np.seterr(divide='raise')   # Numpy treat div 0 as warning and return inf, not exception
 def test_div_raise_zero():
   with pytest.raises((ZeroDivisionError, FloatingPointError)): Tensor(1)/0
   with pytest.raises((ZeroDivisionError, FloatingPointError)): Tensor(1)/Tensor(0)
 def test_inv_raise_zero():
   with pytest.raises((ZeroDivisionError, FloatingPointError)): Tensor(0).inv()
 
-def test_inv():
-  util_test_ops(lambda x: 1/x, Tensor.inv)
-def test_pow():
-  util_test_ops(lambda x,y: x**y, Tensor.pow)
-def test_log():
-  util_test_ops(lambda x: np.log(x), Tensor.log)
-def test_relu():
-  util_test_ops(lambda x: np.maximum(x, 0), Tensor.relu)
-def test_exp():
-  util_test_ops(lambda x: np.exp(x), Tensor.exp)
 def test_neg():
-  util_test_ops(lambda x: -x, Tensor.__neg__)
+  util_test_ops([(10, 10)], lambda x: -x, Tensor.__neg__)
+def test_inv():
+  util_test_ops([(10, 10)], lambda x: 1/x, Tensor.inv)
+def test_log():
+  util_test_ops([(10, 10)], lambda x: torch.log(x), Tensor.log, a=0)
+def test_relu():
+  util_test_ops([(10, 10)], lambda x: torch.relu(x), Tensor.relu)
+def test_exp():
+  util_test_ops([(10, 10)], lambda x: torch.exp(x), Tensor.exp)
 
-
-def util_test_reduce(pyfxn, stfxn):
-  shape = [random.randint(1, 5) for i in range(random.randint(1, 5))]
-  a = np.random.rand(*shape)
-  assert pyfxn(a) == approx(stfxn(Tensor(a)).item), f"fails with input {a}"
-  for i in range(len(shape)):
-    assert pyfxn(a, i) == approx(stfxn(Tensor(a), i).item), f"fails with input {a}"
-
+@pytest.mark.skip(reason="not written")
 def test_sum():
-  util_test_reduce(np.sum, Tensor.sum)
+  pass
+@pytest.mark.skip(reason="not written")
 def test_max():
-  util_test_reduce(np.max, Tensor.max)
+  pass
+@pytest.mark.skip(reason="not written")
 def test_min():
-  util_test_reduce(np.min, Tensor.min)
+  pass
+@pytest.mark.skip(reason="not written")
 def test_mean():
-  util_test_reduce(np.mean, Tensor.mean)
+  pass
+@pytest.mark.skip(reason="not written")
+def test_expand():
+  pass
+@pytest.mark.skip(reason="not written")
+def test_permute():
+  pass


### PR DESCRIPTION
* Just check for the shape of the Tensor when calling backward.

* Does (1,) and () shape the same? PyTorch seem to behave that way.